### PR TITLE
HLS35 Koth Rules changes

### DIFF
--- a/docs/6v6-2.md
+++ b/docs/6v6-2.md
@@ -27,7 +27,7 @@ In the 6v6 format, 5CP maps (such as Process) and KOTH maps (such as Product) ar
 
 ### 5CP
   
-The time limit is set to 30 minutes (mp_timelimit 30) and the win limit to 5 rounds (mp_winlimit 5). The first team to reach five points, or the team with the highest amount of points once the map timer runs out, wins the map. If the map score is tied once the time limit is reached, a decider round (“Golden Cap”) will have to be played.
+The time limit is set to 30 minutes (mp_timelimit 30) and the win limit to 5 rounds (mp_winlimit 5). The round timer is set to 5 minutes. The first team to reach five points, or the team with the highest amount of points once the map timer runs out, wins the map. If the map score is tied once the time limit is reached, a decider round (“Golden Cap”) will have to be played.
 
 #### Golden Cap in 5CP
 

--- a/docs/9v9-2.md
+++ b/docs/9v9-2.md
@@ -15,7 +15,7 @@ In the 9v9 format, 5CP maps (such as Gullywash), A&D and Payload maps (such as S
 
 ### 5CP
 
-The time limit is set to 30 minutes (mp_timelimit 30) and the win difference to 5 rounds (mp_windifference 5). The first team to reach a five point lead over the other, or the team with the highest amount of points once the map timer runs out, wins the map. If the map score is tied once the time limit is reached, a decider round (“Golden Cap”) will have to be played.
+The time limit is set to 30 minutes (mp_timelimit 30) and the win limit to 5 rounds (mp_winlimit 5). The round timer is set to 5 minutes. The first team to reach five points, or the team with the highest amount of points once the map timer runs out, wins the map. If the map score is tied once the time limit is reached, a decider round (“Golden Cap”) will have to be played.
 
 #### Golden Cap in 5CP
 
@@ -24,6 +24,12 @@ The time limit is set to 30 minutes (mp_timelimit 30) and the win difference to 
 The winner of a map that ended with a “Golden Cap” round is awarded 2 league points, while the loser is awarded 1 league point.
 
 ### KOTH (King Of The Hill)
+
+There is no time limit. A win limit of 3 rounds (mp_winlimit 3) is set. The first team to win three rounds in the map wins.
+
+If the final score of a KOTH map has a difference of only 1 point (3-2 or 2-3) it is classified as a “Golden Cap” result, with the winner being the team who won 3 rounds.
+
+### KOTH (King Of The Hill) (alternative Bo7 ruleset)
 
 There is no time limit. A win limit of 2 rounds (mp_winlimit 2) is set. The first team to win four rounds in the map wins.
 
@@ -43,7 +49,7 @@ Here’s an example of a KOTH match extending into a third half:
 
 **Important Note: Once the match is finished, make sure to use `mp_winlimit 1`. This will stop the match and make sure the logs are correct and do not have an extra round.**
 
-If the final score of a KOTH map has a difference of only 1 point (4-3 or 3-4) it is classified as a “Golden Cap” result, with the winner being the team who won 3 rounds.
+If the final score of a KOTH map has a difference of only 1 point (4-3 or 3-4) it is classified as a “Golden Cap” result, with the winner being the team who won 4 rounds.
 
 ### A&D and Payload (Stopwatch)
 


### PR DESCRIPTION
updated the rules that should have been updated before season 50 but we forgot
updated the rules so both bo5 and bo7 rules for koth are covered for highlander